### PR TITLE
Modifications to allow fit_plane and fit_warp during terrain correction.

### DIFF
--- a/src/fit_warp/fit_warp.c
+++ b/src/fit_warp/fit_warp.c
@@ -160,15 +160,15 @@ int main(int argc,char **argv)
 	sample_count = meta->general->sample_count;
 	meta->general->line_count = (int) ceil(line_count/((float) REMAP_CHIP));
 	meta->general->sample_count = (int) ceil(sample_count/((float) REMAP_CHIP));
-	meta_write(meta, appendExt(outName,"_horiz"));
-	meta_write(meta, appendExt(outName,"_vert"));
+	meta_write(meta, appendExt(outName,"horiz"));
+	meta_write(meta, appendExt(outName,"vert"));
 	line_count = meta->general->line_count;
 	sample_count = meta->general->sample_count;
 	
 	printf("Output warping images will be %d lines by %d samples\n",
 	       line_count, sample_count);
-	outH=FOPEN(appendExt(outName,"_horiz.img"),"wb");
-	outV=FOPEN(appendExt(outName,"_vert.img"),"wb");
+	outH=FOPEN(appendExt(outName,"horiz.img"),"wb");
+	outV=FOPEN(appendExt(outName,"vert.img"),"wb");
 	
 	bufH=(float *)MALLOC(sizeof(float)*sample_count);
 	bufV=(float *)MALLOC(sizeof(float)*sample_count);

--- a/src/libasf_raster/fftMatch.c
+++ b/src/libasf_raster/fftMatch.c
@@ -284,7 +284,7 @@ int fftMatch_gridded(char *inFile1, char *inFile2, char *gridFile,
   meta_parameters *meta2 = meta_read(inFile2);
 
   int nl = mini(meta1->general->line_count, meta2->general->line_count);
-  int ns = mini(meta2->general->sample_count, meta2->general->sample_count);
+  int ns = mini(meta1->general->sample_count, meta2->general->sample_count);
 
   const int size = 512;
   const int overlap = 256;
@@ -294,7 +294,8 @@ int fftMatch_gridded(char *inFile1, char *inFile2, char *gridFile,
   char *chip1 = appendToBasename(inFile1, "_chip");
   char *chip2 = appendToBasename(inFile2, "_chip");
   FILE *fp = NULL;
-  if (gridFile)
+  
+  if (gridFile) 
     fp = FOPEN(gridFile, "w");
 
   int num_x = (nl - size) / (size - overlap);
@@ -326,7 +327,7 @@ int fftMatch_gridded(char *inFile1, char *inFile2, char *gridFile,
       if (ok && cert>tol) {
         //asfPrintStatus("Result: dx=%f, dy=%f, cert=%f\n", dx, dy, cert);
         if (fp)
-          fprintf(fp, "%5d %5d %14.5f %14.5f\n", tile_y, tile_x, dx, dy);
+          fprintf(fp, "%5d %5d %14.5f %14.5f %14.5f\n", tile_x, tile_y, tile_x+dx, tile_y+dy, cert);
         x_matches[kk] = dx;
         y_matches[kk] = dy;
         ++kk;

--- a/src/libasf_terrcorr/asf_terrcorr.c
+++ b/src/libasf_terrcorr/asf_terrcorr.c
@@ -96,10 +96,12 @@ static void
 fftMatchQ(char *file1, char *file2, float *dx, float *dy, float *cert)
 {
   int qf_saved = quietflag;
+  char match_file[256];
   quietflag = 1;
   //quietflag = 0;
-
-  fftMatch(file1, file2, NULL, dx, dy, cert);
+  
+  strcpy(match_file,"fft_match.txt");
+  fftMatch_gridded(file1, file2, match_file, dx, dy, cert);
 
   if (!meta_is_valid_double(*dx) || !meta_is_valid_double(*dy) || cert==0) {
       // bad match the first way, sometimes we can get a good match by

--- a/src/remap/quadratic.h
+++ b/src/remap/quadratic.h
@@ -7,28 +7,10 @@ are routines for evaluating, printing, and
 finding (in a least-squares fasion) these functions.
 */
 
-/*
-Quadratic warping coefficients.  Represents a low-order 
-real-valued function of the plane of the form:
-f(x,y)=A+Bx+Cy+Dxx+Exy+Fyy
-*/
-typedef struct {
-	double A,B,C,D,E,F;
-} quadratic_2d;
+#include "asf_meta.h"
 
 /*Evaluate quadratic warp at given location*/
 double quadratic_eval(const quadratic_2d *c,double x,double y);
-
-/*Fit a quadratic warping function to the given points
-in a least-squares fashion.  Resulting function
-maps x,y onto out, so
-out[i] nearly = quadratic_eval(ret,x[i],y[i]);
-*/
-quadratic_2d find_quadratic(const double *out,
-	const double *x,const double *y,int numPts);
-
-/*Write the given quadratic to the given stream.*/
-void quadratic_write(const quadratic_2d *c,FILE *stream);
 
 /*Read a quadratic from the given stream.*/
 void quadratic_read(quadratic_2d *c,FILE *stream);

--- a/src/remap/remap.c
+++ b/src/remap/remap.c
@@ -337,7 +337,10 @@ int main(int argc, char *argv[])
 	/* Write a metadata file for output */
 	meta->general->line_count = outDDR.nl;
 	meta->general->sample_count = outDDR.ns;
-	proj2meta(&outDDR,meta); /* temporary fix to populate the projection fields in the metadata file with DDR information */
+	/* TAL - Removed following line because it was introducing bogus projection 
+		 parameters during terrain correction 
+	proj2meta(&outDDR,meta); /* temporary fix to populate the projection fields 
+				    in the metadata file with DDR information */
 	meta_write(meta,outfile);
 	
 /*Now we just call Perform_mapping, which does the actual I/O and the remapping.*/


### PR DESCRIPTION
Commented out the call to proj2meta
Fixed file name in fit_warp
changed format of output file from fftMatch_gridded
Modified libasf_terrcorr to call fftMatch_gridded (and pass a file name)
