### PR TITLE
Fix for R2 browse image problem.

### DIFF
--- a/src/asf_convert_gui/ceos_thumbnail.c
+++ b/src/asf_convert_gui/ceos_thumbnail.c
@@ -1227,8 +1227,8 @@ make_radarsat2_thumb(const char *input_metadata, const char *input_data,
   char *path = get_dirname(input_metadata);
   if (strlen(path)>0) {
     strcpy(browse_file, path);
-    if (browse_file[strlen(browse_file)-1] != '/')
-      strcat(browse_file, "/");
+    if (browse_file[strlen(browse_file)-1] != DIR_SEPARATOR)
+      browse_file[strlen(browse_file)-1] = DIR_SEPARATOR;
   }
   else
     strcpy(browse_file, "");


### PR DESCRIPTION
Put a more generic test for directory separator in the code. I believe this was a Windows only one.
