### PR TITLE
DE818 - No longer assume lat/lon geotiffs are USGS Seamless DEMs

### DIFF
--- a/src/libasf_import/import_generic_geotiff.c
+++ b/src/libasf_import/import_generic_geotiff.c
@@ -1435,8 +1435,8 @@ meta_parameters * read_generic_geotiff_metadata(const char *inFileName, int *ign
     asfPrintStatus("\nGeoTIFF contains lat/long in decimal degrees.  Assuming this is a\n"
             "USGS Seamless Server (or compatible) type of DEM GeoTIFF with pixel\n"
             "size of 30, 60, 90, or 190 meters, i.e. SRTM, NED, DTED, etcetera...\n");
-    strcpy(mg->sensor, "USGS Seamless data (e.g., NED, SRTM)");
-    strcpy(image_data_type, "DEM");
+    strcpy(mg->sensor, "");
+    strcpy(image_data_type, ""); 
     mg->image_data_type = DEM;
     is_usgs_seamless_geotiff = 1;
   }
@@ -1448,7 +1448,7 @@ meta_parameters * read_generic_geotiff_metadata(const char *inFileName, int *ign
               "USGS Seamless Server (or compatible) type of DEM GeoTIFF with pixel\n"
               "size of 30, 60, 90, 190 meters, i.e. SRTM, NED, DTED, etcetera...\n",
               angular_units_to_string(angular_units));
-      strcpy(mg->sensor, "USGS Seamless data (e.g., NED, SRTM)");
+      strcpy(mg->sensor, "");
       is_usgs_seamless_geotiff = 1; // This will turn on conversion of pixel size from degrees to meters
   }
   else {


### PR DESCRIPTION
I just removed the stuff put in the sensor field of the metadata, all of
the other processing that is done in this situation is left in... it all
seemed harmless and may be needed for some things.
