### PR TITLE
Remove confusing and useless TC pixel size info from summary

### DIFF
--- a/src/asf_convert_gui/summary.c
+++ b/src/asf_convert_gui/summary.c
@@ -166,14 +166,9 @@ const char *get_summary_text()
                 }
             }
 
-            if (s->specified_tc_pixel_size)
+            if (s->specified_pixel_size)
             {
-                sprintf(text, "%s\n   Pixel Size: %.2f m", text,
-                        s->tc_pixel_size);
-            }
-            else if (s->specified_pixel_size)
-            {
-                sprintf(text, "%s\n   Pixel Size: %.2f m (from geocode)",
+                sprintf(text, "%s\n   Pixel Size: %.2f m",
                         text, s->pixel_size);
             }
                     


### PR DESCRIPTION
We got rid of that feature, no need to display it in the summary.
Now just display the geocode pixel size if the user specified it
and leave off the confusing "(from geocode)" stuff.
