### PR TITLE
Proper error message for UAVSAR MLC terrain correction

### DIFF
--- a/src/asf_meta/meta2uavsar.c
+++ b/src/asf_meta/meta2uavsar.c
@@ -607,9 +607,10 @@ meta_parameters* uavsar_polsar2meta(uavsar_polsar *params)
   meta->general->x_pixel_size = params->range_pixel_spacing;
   meta->general->y_pixel_size = fabs(params->azimuth_pixel_spacing);
   meta->general->re_major = params->semi_major;
-  double a = params->semi_major;
+  double re = params->semi_major;
   double ecc2 = params->eccentricity;
-  meta->general->re_minor = sqrt((1-ecc2)*a*a);
+  double rp = sqrt((1-ecc2)*re*re);
+  meta->general->re_minor = rp;
   // no information on bit error rate, missing lines and no data
 
   // SAR block
@@ -645,7 +646,10 @@ meta_parameters* uavsar_polsar2meta(uavsar_polsar *params)
   meta->sar->slant_range_first_pixel = params->slant_range_first_pixel * 1000.0;
   meta->sar->wavelength = params->wavelength / 100.0;
   // no information on pulse repetition frequency
-  // no information on earth radius and satellite height
+  double tan_lat = params->lat_peg_point*D2R;
+  meta->sar->earth_radius = rp*sqrt(1 + tan_lat*tan_lat) /
+    sqrt(rp*rp/(re*re) + tan_lat*tan_lat);
+  // no information on satellite height
   // no time information
   // no Doppler information
   meta->sar->yaw = params->yaw;

--- a/src/libasf_convert/asf_convert.c
+++ b/src/libasf_convert/asf_convert.c
@@ -947,19 +947,17 @@ void check_input(convert_config *cfg, char *processing_step, char *input)
 
     meta = meta_read(input);
       
-    // Check for amplitude data - no other radiometry should make it passed here
-    if (meta->general->radiometry != r_AMP) {
-      // Error out for UAVSAR MLC specifically
-      if (strcmp_case(meta->general->sensor, "UAVSAR") == 0 &&
-	  strcmp_case(meta->general->sensor_name, "PolSAR") == 0 &&
-	  strcmp_case(meta->general->mode, "MLC") == 0)
-	asfPrintError("UAVSAR MLC can't be terrain corrected. "
-		      "Use the UAVSAR GRD data instead.\n"); 
-      // Error out for the rest as well
-      else
-	asfPrintError("Data need to be in amplitude radiometry at this stage "
-		      "in order to be terrain corrected.\n");
-    }
+    // Error out for UAVSAR MLC specifically
+    // We don't have enough metadata to terrain correct at this moment
+    if (strcmp_case(meta->general->sensor, "UAVSAR") == 0 &&
+	strcmp_case(meta->general->sensor_name, "PolSAR") == 0 &&
+	strcmp_case(meta->general->mode, "MLC") == 0)
+      asfPrintError("UAVSAR MLC can't be terrain corrected. "
+		    "Use the UAVSAR GRD data instead.\n"); 
+    // Error out for the rest as well
+    else if (meta->general->radiometry != r_AMP)
+      asfPrintError("Data need to be in amplitude radiometry at this stage "
+		    "in order to be terrain corrected.\n");
   }
   if (meta)
     meta_free(meta);
@@ -1555,8 +1553,6 @@ static int check_config(const char *configFileName, convert_config *cfg)
 		    "terrain corrected product, the matrix files should be "
 		    "radiometrically terrain corrected prior to generating a "
 		    "polarimetric parameter.\n");
-    
-    // Check for pixel size smaller than threshold ???
     
     // specified a mask and asked for an auto-mask
     int have_mask = cfg->terrain_correct->mask &&


### PR DESCRIPTION
Made sure that MapReady errors out properly for any attempts to do terrain correction for UAVSAR MLC data.
Calculated the earth radius for UAVSAR as well. Just leave it in because it does not hurt anybody.
