### PR TITLE
Geographic coordinates fix.

### DIFF
--- a/src/asf_meta/meta2envi.c
+++ b/src/asf_meta/meta2envi.c
@@ -582,7 +582,7 @@ void write_envi_header(const char *headerFile, const char *dataFile,
       {
       case LAT_LONG_PSEUDO_PROJECTION:
 	fprintf(fp, 
-		"map_info = {%s, %d, %d, %.5f, %.5f, %f, %f, %s, units=Degrees}\n", 
+		"map info = {%s, %d, %d, %.5f, %.5f, %f, %f, %s, units=Degrees}\n", 
 		envi->projection, envi->ref_pixel_x, envi->ref_pixel_y,
 		envi->pixel_easting, envi->pixel_northing, envi->proj_dist_x,
 		envi->proj_dist_y, datum_str);


### PR DESCRIPTION
Small typo in geographic coordinates map information. Still something wrong with the ENVI file reading but that is more generic.
