### PR TITLE
Disable creation of unused variable.

### DIFF
--- a/src/asf_meta/distortions.c
+++ b/src/asf_meta/distortions.c
@@ -168,7 +168,7 @@ void map_distortions(meta_projection *proj, double lat, double lon,
   double s = (dy_dlat*dx_dlon - dx_dlat*dy_dlon) * r / cos(lat);
 
   // Meridian/Parallel angle
-  double theta = aasin(s/(h*k));
+  //double theta = aasin(s/(h*k));
 
   // Tissot indicatrix (semimajor and semiminor axes)
   /*


### PR DESCRIPTION
The call to aasin fails in newer versions of PROJ.4 due to new calling conventions. Since the result of aasin isn't used anyway, it's easiest to just comment it out.
