### PR TITLE
A preprocessor macro definition was overwriting a C variable name.

### DIFF
--- a/include/asf_endian.h
+++ b/include/asf_endian.h
@@ -22,7 +22,7 @@ integer "x" from a file, call big16(x).  On a big-endian
 machine, this does nothing; but on a little-endian
 machine, this swaps the bytes properly.  Before writing
 out big-endian data, do the same! */
-#if defined(big_endian)
+#if defined(BIG_ENDIAN)
 #define big16(x) 
 #define big32(x) 
 #define big64(x) 
@@ -30,7 +30,7 @@ out big-endian data, do the same! */
 #define lil32(x) swap32((unsigned char *)&(x))
 #define lil64(x) swap64((unsigned char *)&(x))
 
-#elif defined(lil_endian)
+#elif defined(LIL_ENDIAN)
 #define big16(x) swap16((unsigned char *)&(x))
 #define big32(x) swap32((unsigned char *)&(x))
 #define big64(x) swap64((unsigned char *)&(x))
@@ -38,7 +38,7 @@ out big-endian data, do the same! */
 #define lil32(x) 
 #define lil64(x) 
 #else
-#error "You must set either big_endian or lil_endian"
+#error "You must set either BIG_ENDIAN or LIL_ENDIAN"
 #endif
 
 /*These routines interpret the bytes in an array as integers:*/
@@ -54,7 +54,7 @@ void bigInt32_out(int in,unsigned char *out);
 
 /*These routines convert 16, 32, or 64 bit floating-point data
 to/from big or little endian format.*/
-#if defined(big_ieee)
+#if defined(BIG_IEEE)
 #define ieee_big16(x)
 #define ieee_big32(x) 
 #define ieee_big64(x)
@@ -62,7 +62,7 @@ to/from big or little endian format.*/
 #define ieee_lil32(x) swap32((unsigned char *)&(x))
 #define ieee_lil64(x) swap64((unsigned char *)&(x))
 
-#elif defined(lil_ieee)
+#elif defined(LIL_IEEE)
 #define ieee_big16(x) swap16((unsigned char *)&(x))
 #define ieee_big32(x) swap32((unsigned char *)&(x))
 #define ieee_big64(x) swap64((unsigned char *)&(x))
@@ -70,7 +70,7 @@ to/from big or little endian format.*/
 #define ieee_lil32(x) 
 #define ieee_lil64(x) 
 #else
-#error "You must set either big_ieee or lil_ieee"
+#error "You must set either BIG_IEEE or LIL_IEEE"
 #endif
 
 

--- a/include/asf_nan.h
+++ b/include/asf_nan.h
@@ -11,11 +11,11 @@
  * and will propagate through equations until it's used in a condional
  * statement (which should return False) */
 #ifndef NAN
-# if defined (lil_endian)
+# if defined (LIL_ENDIAN)
 #  define __nan_bytes { 0xff, 0xff, 0xbf, 0x7f }
 # else
 #  define __nan_bytes { 0x7f, 0xbf, 0xff, 0xff }
-# endif /* defined (lil_endian) */
+# endif /* defined (LIL_ENDIAN) */
   static union { unsigned char __c[4]; float __d; } __nan_union = { __nan_bytes };
 # define NAN __nan_union.__d
 #endif /* NAN */

--- a/make_support/endian.c
+++ b/make_support/endian.c
@@ -33,7 +33,7 @@ int main(argc,argv)
 	if (writeRules)
 	{
 		printf("# ENDIAN_FLAGS variable determined by endian.c\n");
-		printf("ENDIAN_FLAGS = -D%s_endian ",littleEndian?"lil":"big");
+		printf("ENDIAN_FLAGS = -D%s_ENDIAN ",littleEndian?"LIL":"BIG");
 	}
 	else
 	{
@@ -81,7 +81,7 @@ int main(argc,argv)
 	if (writeRules)
 	{/*This is a continuation of the "ENDIAN_FLAGS" line from the previous write*/
 		printf("%s\n",
-			ieee?(littleEndian?"-Dlil_ieee":  "-Dbig_ieee"):
+			ieee?(littleEndian?"-DLIL_IEEE":  "-DBIG_IEEE"):
 			          (is_cray?"-Dcray_float":"-Dnon_ieee "));
 	}
 	else

--- a/src/asf_meta/c_getsys.c
+++ b/src/asf_meta/c_getsys.c
@@ -36,12 +36,12 @@ ALGORITHM REFERENCES:
 FUNCTION char *c_getsys(void)
 
 {
-#if defined(lil_ieee)
+#if defined(LIL_IEEE)
 	return IEEE_LIL;
 #elif defined(cray_float)
 	return UNICOS;
 #else
-	/*#if defined(big_ieee)*/
+	/*#if defined(BIG_IEEE)*/
 	return IEEE;
 #endif 
 }

--- a/src/asf_meta/meta2ddr.c
+++ b/src/asf_meta/meta2ddr.c
@@ -39,9 +39,9 @@ void meta2ddr(meta_parameters *meta, struct DDR *ddr)
 	strcpy (ddr->last_used_date,"");
 	strcpy (ddr->last_used_time,"");
 /* System byte ordering style; char[12] */
-	if (0==strcmp(meta_get_system(),"big_ieee"))
+	if (0==strcmp(meta_get_system(),"BIG_IEEE"))
 		strcpy(ddr->system,"ieee-std");
-	else if (0==strcmp(meta_get_system(),"lil_ieee"))
+	else if (0==strcmp(meta_get_system(),"LIL_IEEE"))
 	        strcpy(ddr->system,"ieee-lil");
 		//strcpy(ddr->system,"linux");
 	else if (0==strcmp(meta_get_system(),"cray_float"))

--- a/src/asf_meta/meta_get.c
+++ b/src/asf_meta/meta_get.c
@@ -41,10 +41,10 @@ PROGRAM HISTORY:
  * straight copy of c_getsys "algorithm" for DDR */
 char *meta_get_system(void)
 {
-#if defined(big_ieee)
-    return "big_ieee";
-#elif defined(lil_ieee)
-    return "lil_ieee";
+#if defined(BIG_IEEE)
+    return "BIG_IEEE";
+#elif defined(LIL_IEEE)
+    return "LIL_IEEE";
 #elif defined(cray_float)
     return "cray_float";
 #else

--- a/src/hdr2ddr/c_getsys.c
+++ b/src/hdr2ddr/c_getsys.c
@@ -36,12 +36,12 @@ ALGORITHM REFERENCES:
 FUNCTION char *c_getsys(void)
 
 {
-#if defined(lil_ieee)
+#if defined(LIL_IEEE)
 	return IEEE_LIL;
 #elif defined(cray_float)
 	return UNICOS;
 #else
-	/*#if defined(big_ieee)*/
+	/*#if defined(BIG_IEEE)*/
 	return IEEE;
 #endif 
 }

--- a/src/libasf_raster/float_image.c
+++ b/src/libasf_raster/float_image.c
@@ -1982,9 +1982,9 @@ float_image_band_store(FloatImage *self, const char *file,
   // Establish byte order
   /*
   float_image_byte_order_t byte_order = 0;
-  if (strcmp(meta->general->system, "big_ieee") == 0)
+  if (strcmp(meta->general->system, "BIG_IEEE") == 0)
     byte_order = FLOAT_IMAGE_BYTE_ORDER_BIG_ENDIAN;
-  else if (strcmp(meta->general->system, "lil_ieee") == 0)
+  else if (strcmp(meta->general->system, "LIL_IEEE") == 0)
     byte_order = FLOAT_IMAGE_BYTE_ORDER_LITTLE_ENDIAN;
   */
 
@@ -2035,9 +2035,9 @@ float_image_store (FloatImage *self, const char *file,
   meta = meta_read(file);
 
   //float_image_byte_order_t meta_byte_order = 0;
-  //if (strcmp(meta->general->system, "big_ieee") == 0)
+  //if (strcmp(meta->general->system, "BIG_IEEE") == 0)
   //  meta_byte_order = FLOAT_IMAGE_BYTE_ORDER_BIG_ENDIAN;
-  //else if (strcmp(meta->general->system, "lil_ieee") == 0)
+  //else if (strcmp(meta->general->system, "LIL_IEEE") == 0)
   //  meta_byte_order = FLOAT_IMAGE_BYTE_ORDER_LITTLE_ENDIAN;
 
   //if (meta_byte_order != byte_order)


### PR DESCRIPTION
Capitalized the preprocessor defs 'lil_endian', 'big_endian', 'lil_ieee', and 'big_ieee' to avoid trampling on an unrelated 'big_endian' variable in src/asf_view/read_envi.c, and also to conform to standard practice for cpp defs.
