### PR TITLE
Fixed warnings that caused errors because of -Werror

### DIFF
--- a/src/asf/license.c
+++ b/src/asf/license.c
@@ -12,7 +12,7 @@ void print_copyright()
     t = time(NULL);
     ts = localtime(&t);
     int year = ts->tm_year+1900;
-    printf(ASF_COPYRIGHT_STRING"\n", year);
+    printf(ASF_COPYRIGHT_STRING"\n");
 }
 
 // Print our copyright and license notice & exit

--- a/src/asf_meta/earth_radius2datum.c
+++ b/src/asf_meta/earth_radius2datum.c
@@ -44,7 +44,7 @@ int earth_radius2datum(double re_major, double re_minor)
 		if ( FLOAT_COMPARE(major[major_index],re_major) ) {
 			for (minor_index=0; minor_index<20; minor_index++) {
 				if ( FLOAT_COMPARE(minor[minor_index],re_minor) ) {
-					if ( FLOAT_COMPARE(major_index,minor_index) ) {
+					if (major_index == minor_index) {
 					 	return major_index;
 					}
 				}

--- a/src/asf_meta/getLoc.c
+++ b/src/asf_meta/getLoc.c
@@ -208,7 +208,7 @@ int getLook(GEOLOCATE_REC *g,double range,double yaw,double *plook)
     double sininc,taninc;
     delta_range = range - calcRange(g,look,yaw);
     /* Require decimeter convergence.  */
-    if (abs(delta_range) < 0.1) {
+    if (fabs(delta_range) < 0.1) {
       *plook = look;
       return 0;
     } else { /* Havn't converged yet, so update look angle.  */


### PR DESCRIPTION
Fixed floating point errors, and a 'data argument not used by format string' warning.