### PR TITLE
Fixed the export to GeoTIFF for geographic coordinates. Had to add ba…

### DIFF
--- a/src/color_browse/color_browse.c
+++ b/src/color_browse/color_browse.c
@@ -497,7 +497,7 @@ int main(int argc,char *argv[])
     
     // Export to GeoTIFF
     char *band_names[3] = { "blue", "green", "red" };
-    asf_export_bands(GEOTIFF, NONE, TRUE, FALSE, FALSE, FALSE, FALSE, 
+    asf_export_bands(GEOTIFF, NONE, TRUE, FALSE, FALSE, NULL, FALSE, 
       tmpBrowse, outfile, band_names, NULL, NULL);
 
     // Clean up

--- a/src/libasf_export/export_band.c
+++ b/src/libasf_export/export_band.c
@@ -1169,6 +1169,7 @@ GTIF* write_tags_for_geotiff (TIFF *otif, const char *metadata_file_name,
 	  citation = MALLOC ((max_citation_length + 1) * sizeof (char));
 	  snprintf (citation, max_citation_length + 1, 
 		    "NSIDC EASE-Grid Global");
+		append_band_names(band_names, rgb, citation, palette_color_tiff);
 	  GTIFKeySet (ogtif, PCSCitationGeoKey, TYPE_ASCII, 1, citation);
 	  GTIFKeySet (ogtif, GTCitationGeoKey, TYPE_ASCII, 1, citation);
 	  FREE (citation);
@@ -1208,6 +1209,7 @@ GTIF* write_tags_for_geotiff (TIFF *otif, const char *metadata_file_name,
 	  citation = MALLOC ((max_citation_length + 1) * sizeof (char));
 	  snprintf (citation, max_citation_length + 1, 
 		    "NSIDC EASE-Grid North");
+		append_band_names(band_names, rgb, citation, palette_color_tiff);
 	  GTIFKeySet (ogtif, PCSCitationGeoKey, TYPE_ASCII, 1, citation);
 	  GTIFKeySet (ogtif, GTCitationGeoKey, TYPE_ASCII, 1, citation);
 	  FREE (citation);
@@ -1247,13 +1249,22 @@ GTIF* write_tags_for_geotiff (TIFF *otif, const char *metadata_file_name,
 	  citation = MALLOC ((max_citation_length + 1) * sizeof (char));
 	  snprintf (citation, max_citation_length + 1, 
 		    "NSIDC EASE-Grid South");
+		append_band_names(band_names, rgb, citation, palette_color_tiff);
 	  GTIFKeySet (ogtif, PCSCitationGeoKey, TYPE_ASCII, 1, citation);
 	  GTIFKeySet (ogtif, GTCitationGeoKey, TYPE_ASCII, 1, citation);
 	  FREE (citation);
 	}
 	break;
-      case LAT_LONG_PSEUDO_PROJECTION:
-        {
+  case LAT_LONG_PSEUDO_PROJECTION:
+  {
+	  GTIFKeySet(ogtif, GeographicTypeGeoKey, TYPE_SHORT, 1, 4326);
+	  citation = MALLOC ((max_citation_length + 1) * sizeof (char));
+	  snprintf (citation, max_citation_length + 1, 
+	    "Geographic Coordinates (WGS84)");
+	  append_band_names(band_names, rgb, citation, palette_color_tiff);
+    GTIFKeySet (ogtif, PCSCitationGeoKey, TYPE_ASCII, 1, citation);
+    GTIFKeySet (ogtif, GTCitationGeoKey, TYPE_ASCII, 1, citation);
+    FREE (citation);
 	  write_datum_key(ogtif, md->projection->datum);
 	  write_spheroid_key(ogtif, md->projection->spheroid, re_major, re_minor);
 	}


### PR DESCRIPTION
…nds to the citation. Diffimage did not know anything multiband GeoTIFF ingest. Hooks were there but nothing that would cycle through bands. Cheap fix without changing the signature (less intrusive that way).
