### PR TITLE
Fixed compilation failures related to usage of type bool

### DIFF
--- a/include/ifm.h
+++ b/include/ifm.h
@@ -25,11 +25,6 @@ typedef struct {
     unsigned char blue;
 } RGBDATA;
 
-#ifndef __bool_var
-#define __bool_var
-typedef int bool;
-#endif
-
 #ifndef __data_t_var
 #define __data_t_var
 typedef int data_t;

--- a/src/asf_meta/propagate.h
+++ b/src/asf_meta/propagate.h
@@ -28,7 +28,7 @@ typedef struct {
 
 typedef struct {
   double mean;
-  double true;
+  double isTrue;
   double eccentric;
 } anomaly_t;
 

--- a/src/auto_refine_base/auto_refine_base.c
+++ b/src/auto_refine_base/auto_refine_base.c
@@ -1,5 +1,6 @@
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 #ifndef TRUE
 #define TRUE 1

--- a/src/c2p/c2p.c
+++ b/src/c2p/c2p.c
@@ -64,6 +64,7 @@ BUGS:
 #include "asf_insar.h"
 #include "asf_sar.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 #define VERSION		1.5
 #define BUF		256

--- a/src/coh/coh.c
+++ b/src/coh/coh.c
@@ -89,6 +89,7 @@ BUGS:
 #include "asf_meta.h"
 #include "asf_insar.h"
 #include "ifm.h" /* For Cabs() function */
+#include <stdbool.h>
 
 #define VERSION      2.1
 #define WINDOW_SIZE  3

--- a/src/convert2jpeg/code_jpeg.c
+++ b/src/convert2jpeg/code_jpeg.c
@@ -1,5 +1,6 @@
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "ifm2ppm.h"
 #include "jpeglib.h"
 

--- a/src/convert2jpeg/colortable.c
+++ b/src/convert2jpeg/colortable.c
@@ -25,6 +25,7 @@ PROGRAM HISTORY:
 1.0 - Mike Shindle - Original Development, December 11, 1996.
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 #include "ifm2ppm.h"
 
 /* local constants */

--- a/src/convert2jpeg/convert2jpeg.c
+++ b/src/convert2jpeg/convert2jpeg.c
@@ -85,6 +85,7 @@ BUGS:
 
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "ifm2ppm.h"
 #include "asf_meta.h"
 #include <sys/types.h>  /* for fstat function */

--- a/src/convert2jpeg/decode_jpeg.c
+++ b/src/convert2jpeg/decode_jpeg.c
@@ -5,6 +5,7 @@ it to the given LAS image.
 ****************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "ifm2ppm.h"
 #include "ddr.h"
 

--- a/src/convert2jpeg/jpeg2asf.c
+++ b/src/convert2jpeg/jpeg2asf.c
@@ -74,6 +74,7 @@ BUGS:
 ******************************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "ifm2ppm.h"
 #include "ddr.h"
 

--- a/src/coregister_fine/coherence.c
+++ b/src/coregister_fine/coherence.c
@@ -3,6 +3,7 @@
 #include "las.h"
 #include "asf_meta.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "ddr.h"
 
 #ifndef TWOPI

--- a/src/coregister_fine/coregister_fine.c
+++ b/src/coregister_fine/coregister_fine.c
@@ -109,6 +109,7 @@ BUGS:
 #include "asf.h"
 #include "asf_meta.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_endian.h"
 
 #define borderX 80	/*Distances from edge of image to start correlating.*/

--- a/src/coregister_fine/fft_corr.c
+++ b/src/coregister_fine/fft_corr.c
@@ -1,6 +1,7 @@
 /*GetFFTCorrelation: computes the maximum FFT value of a given interferogram.*/
 #include "fft.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include <math.h>
 
 float getFFTCorrelation(complexFloat *igram,int sizeX,int sizeY);

--- a/src/detect_cr/detect_cr.c
+++ b/src/detect_cr/detect_cr.c
@@ -104,6 +104,7 @@ file. Save yourself the time and trouble, and use edit_man_header.pl. :)
 #include "asf_nan.h"
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 #include "fft.h"
 #include "fft2d.h"

--- a/src/detect_cr/detect_cr.h
+++ b/src/detect_cr/detect_cr.h
@@ -4,6 +4,7 @@
 #define FLAG_SET 1
 #define FLAG_NOT_SET -1
 #include "ifm.h"
+#include <stdbool.h>
 
 /* Index keys for all flags used in this program via a 'flags' array */
 typedef enum {

--- a/src/escher/escher.h
+++ b/src/escher/escher.h
@@ -1,6 +1,7 @@
 
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "ddr.h"
 #include "asf_meta.h"
 

--- a/src/igram/igram.c
+++ b/src/igram/igram.c
@@ -85,6 +85,7 @@ BUGS:
 
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 
 /*

--- a/src/libasf_insar/asf_coregister.c
+++ b/src/libasf_insar/asf_coregister.c
@@ -5,6 +5,7 @@
 #include "functions.h"
 #include "fft.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_endian.h"
 
 // Coarse coregistration

--- a/src/libasf_insar/escher.c
+++ b/src/libasf_insar/escher.c
@@ -1,5 +1,6 @@
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 #include "asf_endian.h"
 #include "asf_insar.h"

--- a/src/libasf_insar/multilook.c
+++ b/src/libasf_insar/multilook.c
@@ -2,6 +2,7 @@
 #include "asf_meta.h"
 #include "asf_export.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 /* local constants */
 #define VERSION 4.0

--- a/src/libasf_insar/refine_baseline.c
+++ b/src/libasf_insar/refine_baseline.c
@@ -1,5 +1,6 @@
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 
 // Local function declaration

--- a/src/libifm/SNR.c
+++ b/src/libifm/SNR.c
@@ -29,6 +29,7 @@ PROGRAM HISTORY:
 #include "asf.h"
 
 #include "ifm.h"
+#include <stdbool.h>
 
 float SNR(float *v, int n, int x, int y, int d)
 {

--- a/src/libifm/c2p.c
+++ b/src/libifm/c2p.c
@@ -30,6 +30,7 @@ BUGS:
 
 
 #include "ifm.h"
+#include <stdbool.h>
 
 
 int 

--- a/src/libifm/cabs.c
+++ b/src/libifm/cabs.c
@@ -21,6 +21,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 
 #include "ifm.h"
+#include <stdbool.h>
 
 float Cabs(complexFloat a)
 {

--- a/src/libifm/cadd.c
+++ b/src/libifm/cadd.c
@@ -33,6 +33,7 @@ BUGS:
 
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 
 complexDouble Cadd_d(complexDouble a, complexDouble b) {

--- a/src/libifm/cconj.c
+++ b/src/libifm/cconj.c
@@ -23,6 +23,7 @@ PROGRAM HISTORY:
    1.0 - Mike Shindle & Rob Fatland. Original Development.
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 complexFloat Cconj(complexFloat a)
 {

--- a/src/libifm/checkDataType.c
+++ b/src/libifm/checkDataType.c
@@ -22,6 +22,7 @@ PROGRAM HISTORY:
     1.0 - Rob Fatland & Mike Shindle - Original Devlopment
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 int checkDataType(data_t type)
 {

--- a/src/libifm/cmul.c
+++ b/src/libifm/cmul.c
@@ -21,6 +21,7 @@ PROGRAM HISTORY:
   1.0  - Mike Shindle & Rob Fatland. Original development.
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 complexFloat Cmul(complexFloat a, complexFloat b)
 {

--- a/src/libifm/cphase.c
+++ b/src/libifm/cphase.c
@@ -21,6 +21,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 
 #include "ifm.h"
+#include <stdbool.h>
 
 float Cphase(complexFloat a)
 {

--- a/src/libifm/cpxmatrix.c
+++ b/src/libifm/cpxmatrix.c
@@ -1,6 +1,7 @@
 #include "asf.h"
 
 #include "ifm.h"
+#include <stdbool.h>
 
 complexFloat **cpxmatrix(int nrl, int nrh, int ncl, int nch)
 {

--- a/src/libifm/cpxvector.c
+++ b/src/libifm/cpxvector.c
@@ -1,6 +1,7 @@
 #include "asf.h"
 
 #include "ifm.h"
+#include <stdbool.h>
 
 complexFloat *cpxvector(int nl, int nh)
 {

--- a/src/libifm/csdiv.c
+++ b/src/libifm/csdiv.c
@@ -22,6 +22,7 @@ PROGRAM HISTORY:
     1.0 - Mike Shindle & Rob Fatland - Original Development
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 complexFloat Csdiv(float s, complexFloat a) {
    complexFloat x;

--- a/src/libifm/csmul.c
+++ b/src/libifm/csmul.c
@@ -21,6 +21,7 @@ PROGRAM HISTORY:
   1.0  - Mike Shindle & Rob Fatland. Original development.
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 complexFloat Csmul(float s, complexFloat b)
 {

--- a/src/libifm/czero.c
+++ b/src/libifm/czero.c
@@ -30,6 +30,7 @@ BUGS:
 
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 complexFloat Czero() {
   complexFloat zero;

--- a/src/libifm/fft2d.c
+++ b/src/libifm/fft2d.c
@@ -29,6 +29,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 
 #include "ifm.h"
+#include <stdbool.h>
 
 void fourn(float *data, int *nn, int ndim, int isign);
 

--- a/src/libifm/fileNumLines.c
+++ b/src/libifm/fileNumLines.c
@@ -24,6 +24,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 int fileNumLines(char *fname)
 {

--- a/src/libifm/fourn.c
+++ b/src/libifm/fourn.c
@@ -36,6 +36,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 
 #include "ifm.h"
+#include <stdbool.h>
 
 void fourn(float *data, int *nn, int ndim, int isign)
 {

--- a/src/libifm/get_mean.c
+++ b/src/libifm/get_mean.c
@@ -22,6 +22,7 @@ PROGRAM HISTORY:
 
 
 #include "ifm.h"
+#include <stdbool.h>
 
 float get_mean(FILE *famp, int ns, int nl, int doAvg)
 {

--- a/src/libifm/get_meand.c
+++ b/src/libifm/get_meand.c
@@ -22,6 +22,7 @@ PROGRAM HISTORY:
 
 
 #include "ifm.h"
+#include <stdbool.h>
 
 double get_meand(FILE *famp, int ns, int nl, int doAvg)
 {

--- a/src/libifm/imos2d.c
+++ b/src/libifm/imos2d.c
@@ -27,6 +27,7 @@ PROGRAM HISTORY:
 #include "asf.h"
 #include "imsl.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 /* function declarations */
 int init_coeff(int);

--- a/src/libifm/minv1.c
+++ b/src/libifm/minv1.c
@@ -19,6 +19,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 #ifdef EPSILON
 #undef EPSILON

--- a/src/libifm/mxv1.c
+++ b/src/libifm/mxv1.c
@@ -21,6 +21,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 /* prototype */
 int fcpvec(float *from, float *to, int nitems);

--- a/src/libifm/os2d.c
+++ b/src/libifm/os2d.c
@@ -24,6 +24,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 /* Prototypes */
 void fft2d (complexFloat *array, int n, int direction);

--- a/src/libifm/oversamp2dCpx.c
+++ b/src/libifm/oversamp2dCpx.c
@@ -27,6 +27,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 /* Prototype */
 void os2d(complexFloat *v, complexFloat *vo, int dim, int os);

--- a/src/libifm/print.c
+++ b/src/libifm/print.c
@@ -21,6 +21,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 /* print n-vector in a column */
 void 

--- a/src/libifm/readMatrix.c
+++ b/src/libifm/readMatrix.c
@@ -41,6 +41,7 @@ PROGRAM HISTORY:
 #include <unistd.h>
 #include <fcntl.h>
 #include "ifm.h"
+#include <stdbool.h>
 
 void readMatrix(fnm, a, type, m, n, c0, r0, M, N, h0, h1)
 char   *fnm;      /* source filename                   */

--- a/src/libifm/readVector.c
+++ b/src/libifm/readVector.c
@@ -25,6 +25,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 
 #include "ifm.h"
+#include <stdbool.h>
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/src/libifm/rm_sic.c
+++ b/src/libifm/rm_sic.c
@@ -40,6 +40,7 @@ PROGRAM HISTORY:
 #include <unistd.h>
 #include <fcntl.h>
 #include "ifm.h"
+#include <stdbool.h>
 
 void ReadMatrixFromSIC(char *fnm,            /* source filename       */
                        SIComplex **a,        /* destination buffer    */

--- a/src/libifm/svdcmp.c
+++ b/src/libifm/svdcmp.c
@@ -1,5 +1,6 @@
 
 #include "ifm.h"
+#include <stdbool.h>
 
 static float at,bt,ct;
 static float maxarg1,maxarg2;

--- a/src/libifm/vector.c
+++ b/src/libifm/vector.c
@@ -1,6 +1,7 @@
 #include "asf.h"
 
 #include "ifm.h"
+#include <stdbool.h>
 
 float *
 alloc_vector(int nl, int nh)

--- a/src/libifm/wks_allocate.c
+++ b/src/libifm/wks_allocate.c
@@ -21,6 +21,7 @@ PROGRAM HISTORY:
 
 #include "imsl.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 /* imsl functions */
 extern fftci_();

--- a/src/libifm/writeAsciiVector.c
+++ b/src/libifm/writeAsciiVector.c
@@ -27,6 +27,7 @@ PROGRAM HISTORY:
 ****************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 
 void writeAsciiVector(void *v, char *fnm, data_t type, int n)
 {

--- a/src/libifm/writeVector.c
+++ b/src/libifm/writeVector.c
@@ -30,6 +30,7 @@ PROGRAM HISTORY:
 #include <unistd.h>
 #include <fcntl.h>
 #include "ifm.h"
+#include <stdbool.h>
 
 void writeVector (void *v, char *fnm, data_t type, int n)
 {

--- a/src/libifm/zeroPad.c
+++ b/src/libifm/zeroPad.c
@@ -43,6 +43,7 @@ PROGRAM HISTORY:
   1.0 - Rob Fatland & Mike Shindle - Original Development
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 void zeroPad(complexFloat *vIn, complexFloat *vOut, int dim, int os)
 {

--- a/src/libifm/zeroPad2d.c
+++ b/src/libifm/zeroPad2d.c
@@ -43,6 +43,7 @@ PROGRAM HISTORY:
   1.0 - Rob Fatland & Mike Shindle - Original Development
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 
 void zeroPad2d(complexFloat **vIn, complexFloat **vOut, int dim, int os)
 {

--- a/src/multilook/c2i.c
+++ b/src/multilook/c2i.c
@@ -33,6 +33,7 @@ PROGRAM HISTORY:
 #include "asf.h"
 
 #include "ifm.h"
+#include <stdbool.h>
 #include "multilook.h"
 
 int c2i(float *amp, float *phase, RGBDATA *image, RGBDATA *table, int nsamples, float avg)

--- a/src/multilook/colortable.c
+++ b/src/multilook/colortable.c
@@ -22,6 +22,7 @@ PROGRAM HISTORY:
 1.0 - Mike Shindle - Original Development
 ****************************************************************/
 #include "ifm.h"
+#include <stdbool.h>
 #include "multilook.h"
 
 void 

--- a/src/multilook/multilook.c
+++ b/src/multilook/multilook.c
@@ -91,6 +91,7 @@ BUGS:
 #include "asf.h"
 #include "las.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 #include "multilook.h"
 #include "lzFetch.h"

--- a/src/offset_test/fft_corr.c
+++ b/src/offset_test/fft_corr.c
@@ -1,6 +1,7 @@
 /*GetFFTCorrelation: computes the maximum FFT value of a given interferogram.*/
 #include "fft.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include <math.h>
 
 float getFFTCorrelation(complexFloat *igram,int sizeX,int sizeY);

--- a/src/offset_test/offset_test.c
+++ b/src/offset_test/offset_test.c
@@ -98,8 +98,6 @@ file. Save yourself the time and trouble, and use edit_man_header.pl. :)
 /*===================END ASF AUTO-GENERATED DOCUMENTATION===================*/
 
 #include "asf.h"
-#include "ifm.h"
-#include <stdbool.h>
 #include "asf_meta.h"
 #include "fft.h"
 #include "fft2d.h"

--- a/src/offset_test/offset_test.c
+++ b/src/offset_test/offset_test.c
@@ -99,10 +99,12 @@ file. Save yourself the time and trouble, and use edit_man_header.pl. :)
 
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 #include "fft.h"
 #include "fft2d.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "offset_test.h"
 
 #define NUM_ARGS 3

--- a/src/pta/pta.h
+++ b/src/pta/pta.h
@@ -4,6 +4,7 @@
 #define FLAG_SET 1
 #define FLAG_NOT_SET -1
 #include "ifm.h"
+#include <stdbool.h>
 #include <fftw3.h>
 
 /* Evaluate to true if floats are within tolerance of each other.  */

--- a/src/refine_base/bp.c
+++ b/src/refine_base/bp.c
@@ -54,6 +54,7 @@ BUGS:
 ******************************************************************************/
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 
 /* local function declaration */

--- a/src/refine_base/genab.c
+++ b/src/refine_base/genab.c
@@ -1,5 +1,6 @@
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 
 /* for convenience in a diagnostic */

--- a/src/refine_base/getphase.c
+++ b/src/refine_base/getphase.c
@@ -1,5 +1,6 @@
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 
 

--- a/src/refine_base/test_base.c
+++ b/src/refine_base/test_base.c
@@ -1,5 +1,6 @@
 #include "asf.h"
 #include "ifm.h"
+#include <stdbool.h>
 #include "asf_meta.h"
 
 int test_base(char *basefile, char *matfile, char *vecfile)


### PR DESCRIPTION
Using gcc 6.3 on Debian 9 (Stretch), compilation fails because:
1. in struct `anomaly_t` in `src/asf_meta/propagate.h` there is a field labelled "true"
2. in `include/ifm.h` the type definition for bool is problematic

This pull request fixes these problems by:
1. renaming the field "true" to "isTrue"
2. replacing the custom boolean type definition with stdbool.h which provides a type `bool`