### PR TITLE
Updated Debian control file and packaging target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -471,6 +471,7 @@ deb: default
 	strip asf-mapready/@prefix@/bin/*
 	sed -e "/Version:/s/$$/ $(DEBIAN_VERSION)/" \
 	    -e "/Installed-Size:/s|$$| $$(expr $$(expr $$(du -bs asf-mapready@prefix@|cut -f1) + 512) / 1024)|" \
+		-e "s/\(Architecture:\)/\1 $$(dpkg --print-architecture)/" \
 		<debian/control \
 		>asf-mapready/DEBIAN/control
 	fakeroot dpkg-deb --build asf-mapready

--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,8 @@ Version:
 Priority: optional
 Section: science
 Maintainer: Jenkins <uso@asf.alaska.edu>
-Architecture: amd64
-Depends: libgdal1h, libgtk2.0-0, libglade2-0, libtiff5, libgeotiff2, libcunit1, libproj0, libhdf5-8, libgsl0ldbl, libshp2, libfftw3-3
+Architecture: all
+Depends: libgdal20, libgtk2.0-0, libglade2-0, libtiff5, libgeotiff2, libcunit1, libproj12, libhdf5-100, libgsl2, libshp2, libfftw3-3
 Description: Terrain correct and geocode multi-pol SAR data.
  The MapReady Remote Sensing Tool Kit accepts level 1 detected SAR data, single
  look complex SAR data, and optical data from ASF and some other facilities. It

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version:
 Priority: optional
 Section: science
 Maintainer: Jenkins <uso@asf.alaska.edu>
-Architecture: all
+Architecture: 
 Depends: libgdal20, libgtk2.0-0, libglade2-0, libtiff5, libgeotiff2, libcunit1, libproj12, libhdf5-100, libgsl2, libshp2, libfftw3-3
 Description: Terrain correct and geocode multi-pol SAR data.
  The MapReady Remote Sensing Tool Kit accepts level 1 detected SAR data, single


### PR DESCRIPTION
This pull request:
- updates the dependencies in `debian/control` for Debian 9 (Stretch)
- updates the `deb` make target to automatically fill in the architecture