### PR TITLE
Make noiseVectorList look up variable to support format change

### DIFF
--- a/src/libasf_import/import_sentinel.c
+++ b/src/libasf_import/import_sentinel.c
@@ -425,7 +425,7 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
     asfPrintError("Could not get root element %s\n", xmlFile);
   
   // Get dimensions
-  sprintf(xpath, "/noise/noiseVectorList/noiseVector")
+  sprintf(xpath, "/noise/noiseVectorList/noiseVector");
   int line_count = xml_xpath_get_int_value(doc, 
     "/noise/noiseVectorList/@count");
   

--- a/src/libasf_import/import_sentinel.c
+++ b/src/libasf_import/import_sentinel.c
@@ -427,20 +427,20 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
     asfPrintError("Could not get root element %s\n", xmlFile);
   
   // Get dimensions
-  sprintf(xpath, "/noise/noiseVectorList/noiseVector");
-  int line_count = xml_xpath_get_int_value(doc, 
-    "/noise/noiseVectorList/@count");
+  strcpy(xpath, "/noise/noiseVectorList/noiseVector");
+  if (!xml_xpath_element_exists(doc, xpath)){
+      asfPrintStatus("Using alternative noiseRangeVectorList");
+      strcpy(range, "Range")
+  }else{    
+      strcpy(range, "")
+        
+  sprintf(xpath, "/noise/noise%sVectorList/", range);
+  sprintf(str, "%s/@count", xpath)
+    
+  int line_count = xml_xpath_get_int_value(doc, str)
   
   // Location of NoiseLut changed from noiseVectorList to noiseRangeVectorList
-  if (line_count == MAGIC_UNSET_INT){
-      strcpy(xpath, "/noise/noiseRangeVectorList/noiseRangeVector");
-      strcpy(range, "Range")
-      asfPrintStatus("Using alternative noiseRangeVectorList: %s", xpath);
-      line_count = xml_xpath_get_int_value(doc, 
-         "/noise/noiseRangeVectorList/@count");
-  }else{
-      strcpy(range, "")   
-  }
+  sprintf(xpath, "/noise/noise%sVectorList/noise%sVector", range, range)  
   
   sentinel_lut_line *lut = 
     (sentinel_lut_line *) MALLOC(sizeof(sentinel_lut_line)*line_count);

--- a/src/libasf_import/import_sentinel.c
+++ b/src/libasf_import/import_sentinel.c
@@ -432,7 +432,7 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
     "/noise/noiseVectorList/@count");
   
   // Location of NoiseLut changed from noiseVectorList to noiseRangeVectorList
-  if (line_count == MAGIC_UNSET_STRING){
+  if (line_count == MAGIC_UNSET_INT){
       strcpy(xpath, "/noise/noiseRangeVectorList/noiseRangeVector");
       strcpy(range, "Range")
       asfPrintStatus("Using alternative noiseRangeVectorList: %s", xpath);

--- a/src/libasf_import/import_sentinel.c
+++ b/src/libasf_import/import_sentinel.c
@@ -412,6 +412,8 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
   int kk, ll, line, pixel_count;
   char *str = (char *) MALLOC(sizeof(char)*512);
   char *xpath = (char *) MALLOC(sizeof(char)*512);
+  char *range = (char *) MALLOC(sizeof(char)*32);
+  
   char pixelStr[8192], noiseStr[16384], **pixel, **noise;
   float minNoise = 9999999;
   float maxNoise = -9999999;
@@ -432,10 +434,11 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
   // Location of NoiseLut changed from noiseVectorList to noiseRangeVectorList
   if (line_count == MAGIC_UNSET_STRING){
       strcpy(xpath, "/noise/noiseRangeVectorList/noiseRangeVector");
+      strcpy(range, "Range")
       line_count = xml_xpath_get_int_value(doc, 
          "/noise/noiseRangeVectorList/@count");
   }else{
-      strcpy(xpath, "/noise/noiseVectorList/noiseRangeList");
+      strcpy(range, "")   
   }
   
   sentinel_lut_line *lut = 
@@ -448,7 +451,7 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
     sprintf(str, "%s[%d]/pixel", xpath, kk+1);
     strcpy(pixelStr, xml_xpath_get_string_value(doc, str));
     split_into_array(pixelStr, ' ', &pixel_count, &pixel);
-    sprintf(str, "%s[%d]/noiseLut", xpath, kk+1);
+    sprintf(str, "%s[%d]/noise%sLut", xpath, kk+1, range);
     strcpy(noiseStr, xml_xpath_get_string_value(doc, str));
     split_into_array(noiseStr, ' ', &pixel_count, &noise);
     lut[kk].line = line;

--- a/src/libasf_import/import_sentinel.c
+++ b/src/libasf_import/import_sentinel.c
@@ -435,6 +435,7 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
   if (line_count == MAGIC_UNSET_STRING){
       strcpy(xpath, "/noise/noiseRangeVectorList/noiseRangeVector");
       strcpy(range, "Range")
+      asfPrintStatus("Using alternative noiseRangeVectorList: %s", xpath);
       line_count = xml_xpath_get_int_value(doc, 
          "/noise/noiseRangeVectorList/@count");
   }else{

--- a/src/libasf_import/import_sentinel.c
+++ b/src/libasf_import/import_sentinel.c
@@ -427,15 +427,14 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
     asfPrintError("Could not get root element %s\n", xmlFile);
   
   // Get dimensions
-  strcpy(xpath, "/noise/noiseVectorList/noiseVector");
+  strcpy(xpath, "/noise/noiseVectorList");
   if (!xml_xpath_element_exists(doc, xpath)){
       asfPrintStatus("Using alternative noiseRangeVectorList");
       strcpy(range, "Range")
   }else{    
       strcpy(range, "")
         
-  sprintf(xpath, "/noise/noise%sVectorList/", range);
-  sprintf(str, "%s/@count", xpath)
+  sprintf(str, "/noise/noise%sVectorList/@count", range, xpath)
     
   int line_count = xml_xpath_get_int_value(doc, str)
   

--- a/src/libasf_import/import_sentinel.c
+++ b/src/libasf_import/import_sentinel.c
@@ -434,7 +434,7 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
   }else{    
       strcpy(range, "")
         
-  sprintf(str, "/noise/noise%sVectorList/@count", range, xpath)
+  sprintf(str, "/noise/noise%sVectorList/@count", range)
     
   int line_count = xml_xpath_get_int_value(doc, str)
   

--- a/src/libasf_import/import_sentinel.c
+++ b/src/libasf_import/import_sentinel.c
@@ -429,17 +429,18 @@ static sentinel_lut_line *read_sentinel_noise(char *xmlFile, char *mode,
   // Get dimensions
   strcpy(xpath, "/noise/noiseVectorList");
   if (!xml_xpath_element_exists(doc, xpath)){
-      asfPrintStatus("Using alternative noiseRangeVectorList");
-      strcpy(range, "Range")
+    asfPrintStatus("Using alternative noiseRangeVectorList");
+    strcpy(range, "Range");
   }else{    
-      strcpy(range, "")
+    strcpy(range, "");
+  }
         
-  sprintf(str, "/noise/noise%sVectorList/@count", range)
+  sprintf(str, "/noise/noise%sVectorList/@count", range);
     
-  int line_count = xml_xpath_get_int_value(doc, str)
+  int line_count = xml_xpath_get_int_value(doc, str);
   
   // Location of NoiseLut changed from noiseVectorList to noiseRangeVectorList
-  sprintf(xpath, "/noise/noise%sVectorList/noise%sVector", range, range)  
+  sprintf(xpath, "/noise/noise%sVectorList/noise%sVector", range, range);  
   
   sentinel_lut_line *lut = 
     (sentinel_lut_line *) MALLOC(sizeof(sentinel_lut_line)*line_count);


### PR DESCRIPTION
In late 2017, early 2018, Sentinel will split noiseVector into separate Range and Azimuth vectors.

https://sentinels.copernicus.eu/web/sentinel/news/-/asset_publisher/xR9e/content/sentinel-1-update-of-product-format