### PR TITLE
"Fixed" our long standing issue of not being able to build MapReady w…

### DIFF
--- a/configure
+++ b/configure
@@ -620,6 +620,7 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+TMPDIR
 DOCDIR
 BINDIR
 SHAREDIR
@@ -696,6 +697,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -805,6 +807,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1057,6 +1060,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1194,7 +1206,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1347,6 +1359,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -6788,6 +6801,9 @@ BINDIR="$prefix/bin"
 
 
 DOCDIR="$prefix/doc"
+
+
+TMPDIR="/tmp"
 
 
 ac_config_files="$ac_config_files Makefile include/config.h"

--- a/configure.ac
+++ b/configure.ac
@@ -468,6 +468,7 @@ DOCDIR="$prefix/doc"
 AC_SUBST(DOCDIR)
 
 TMPDIR="/tmp"
+AC_SUBST(TMPDIR)
 
 AC_OUTPUT([
 Makefile

--- a/src/libasf_import/Makefile
+++ b/src/libasf_import/Makefile
@@ -84,7 +84,6 @@ OBJS  = \
 	import_terrasar.o \
 	import_polsarpro.o \
 	import_fgdc_meta.o \
-	import_dem.o \
 	import_roipac.o \
 	import_smap.o \
 	import_seasat_h5.o \


### PR DESCRIPTION
…ith 'make'. It does now, as 'aclocal' and 'autoconf' do not throw any errors anymore. Might have something to do with removing the external libraries from the build.