### PR TITLE
Apparently had not checked in the change for 'clm' that actually retu…

### DIFF
--- a/src/clm/clm.c
+++ b/src/clm/clm.c
@@ -246,7 +246,7 @@ main (int argc, char *argv[])
     meta_parameters *meta = meta_read(meta_file);
 
     int ii,jj;
-    for (jj=0, ii=currArg+2; ii<argc; ++ii, ++jj) {
+    for (jj=0, ii=currArg+3; ii<argc; ++ii, ++jj) {
       if (strcmp_case(argv[ii], "CL") == 0) {
         args[jj] = meta->general->line_count/2.0;
       } else if (strcmp_case(argv[ii], "CS") == 0) {

--- a/src/libasf_terrcorr/asf_terrcorr.c
+++ b/src/libasf_terrcorr/asf_terrcorr.c
@@ -660,7 +660,7 @@ int match_dem(meta_parameters *metaSAR,
   char *demClipped = NULL, *demSlant = NULL;
   char *demSimSar = NULL;
   int num_attempts = 0;
-  const int max_attempts = 5; // # of times we re-try co-registration
+  const int max_attempts = 10; // # of times we re-try co-registration
   const float required_match = 2.5;
   double t_off, x_off;
   int redo_clipping;


### PR DESCRIPTION
…rns correct values for all functions. Increased the number of iterations for matching (primarily refine_geolocation, but also asf_terrcorr).