### PR TITLE
Add pre-processing conditional directive to ensure that we don't attempt to type-define bool twice

### DIFF
--- a/include/ifm.h
+++ b/include/ifm.h
@@ -25,7 +25,7 @@ typedef struct {
     unsigned char blue;
 } RGBDATA;
 
-#if __GNUC__ < 7
+#if __GNUC__ < 7 && !defined(bool)
   #ifndef __bool_var
   #define __bool_var
   typedef int bool;


### PR DESCRIPTION
Addresses compilation error

In file included from /usr/local/include/H5public.h:147:0,
                 from /usr/local/include/hdf5.h:22,
                 from ../../include/asf_meta.h:35,
                 from asf_coregister.c:2:
../../include/ifm.h:31:15: error: two or more data types in declaration specifiers
   typedef int bool;
               ^
In file included from asf_coregister.c:7:0:
../../include/ifm.h:31:3: warning: useless type name in empty declaration [enabled by default]
   typedef int bool;
   ^
make[1]: *** [asf_coregister.o] Error 1
make[1]: Leaving directory `/home/jlm/src/aux/ASF_MapReady/src/libasf_insar'
make: *** [mapready] Error 2
