### PR TITLE
update dependency due to error: configure: library fftw was not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ On other systems, the package names may vary.
 The following commands on the most recent Ubuntu should get you up
 and running:
 
-* sudo apt-get install git bison flex g++ gcc libgdal-dev libgtk2.0-dev libglade2-dev libgsl-dev libproj-dev libtiff-dev libgeotiff-dev shapelib libshp-dev libcunit1-dev
+* sudo apt-get install git bison flex g++ gcc libgdal-dev libgtk2.0-dev libglade2-dev libgsl-dev libproj-dev libtiff-dev libgeotiff-dev shapelib libshp-dev libcunit1-dev fftw-dev
 * git clone git@github.com/asfadmin/ASF_MapReady.git ASF_MapReady
 * cd ASF_MapReady
 * ./configure


### PR DESCRIPTION
Dear Sir or Madam at ASF,
On Ubuntu 20 LTS I followed the instructions and got "configure: error: library fftw was not found"
Suggest adding  fftw-dev to the apt-get command in the README.md if of interest. Could save some folks a step
Thanks for considering this request. And thank you to your whole team for all the amazing software and science! Much appreciated 
Best regards,
Ash